### PR TITLE
Add parse function that takes just cigar string without sequences

### DIFF
--- a/src/cigar.rs
+++ b/src/cigar.rs
@@ -447,4 +447,18 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn from_string_no_counts() {
+        let c = Cigar::from_string("=XIDDD");
+        assert_eq!(
+            c.ops,
+            vec![
+                CigarElem::new(CigarOp::Match, 1),
+                CigarElem::new(CigarOp::Sub, 1),
+                CigarElem::new(CigarOp::Ins, 1),
+                CigarElem::new(CigarOp::Del, 3),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
When testing with structs containing `Cigar` it's nice to be able to construct the `Cigar` without having the original sequences, like:

```rust
let m = some_code()
assert_eq!(m, 
  Match {
     start: 10
     ...
     Cigar::from_string("24=")
  }
)
```